### PR TITLE
Vvnkr/pivot tables

### DIFF
--- a/sheetwhat/checks/check_pivot.py
+++ b/sheetwhat/checks/check_pivot.py
@@ -75,9 +75,7 @@ class DictKeyEqualityRule(Rule):
     def __call__(self, path, message):
         solution_dict = safe_glom(self.solution_pivot_table, path)
         student_dict = safe_glom(self.student_pivot_table, path)
-        if not isinstance(student_dict, dict):
-            return
-        if not isinstance(solution_dict, dict):
+        if not isinstance(student_dict, dict) or not isinstance(solution_dict, dict):
             return
         solution_key_set = set(solution_dict.keys())
         student_key_set = set(student_dict.keys())
@@ -257,7 +255,8 @@ def has_equal_pivot(state, extra_msg=None):
                 safe_glom(student_pivot_table, "criteria"),
             ):
                 bound_rules["set_equality"](
-                    f"criteria.{key}.visibleValues", "error"
+                    f"criteria.{key}.visibleValues",
+                    "The filtered out values are incorrect.",
                 )
 
             nb_issues = len(issues)

--- a/sheetwhat/checks/check_pivot.py
+++ b/sheetwhat/checks/check_pivot.py
@@ -115,6 +115,20 @@ class OverExistenceRule(Rule):
             self.issues.append(message)
 
 
+class SetEqualityRule(Rule):
+    def __call__(self, path, message):
+        solution_array = safe_glom(self.solution_pivot_table, path)
+        student_array = safe_glom(self.student_pivot_table, path)
+        if not isinstance(student_array, list):
+            return
+        if not isinstance(solution_array, list):
+            return
+        solution_set = set(solution_array)
+        student_set = set(student_array)
+        if solution_set != student_set:
+            self.issues.append(message)
+
+
 rule_types = {
     "array_equal_length": ArrayEqualLengthRule,
     "array_equality": ArrayEqualityRule,
@@ -122,6 +136,7 @@ rule_types = {
     "equality": EqualityRule,
     "existence": ExistenceRule,
     "over_existence": OverExistenceRule,
+    "set_equality": SetEqualityRule,
 }
 
 
@@ -234,17 +249,16 @@ def has_equal_pivot(state, extra_msg=None):
                 ),
             )
 
+            bound_rules["dict_key_equality"](
+                "criteria", "The rows or columns used in the filter are incorrect."
+            )
             for key in dict_keys(
                 safe_glom(solution_pivot_table, "criteria"),
                 safe_glom(student_pivot_table, "criteria"),
             ):
-                bound_rules["array_equal_length"](
+                bound_rules["set_equality"](
                     f"criteria.{key}.visibleValues", "error"
                 )
-
-            bound_rules["dict_key_equality"](
-                "criteria", "The rows or columns used in the filter are incorrect."
-            )
 
             nb_issues = len(issues)
             if nb_issues > 0:

--- a/sheetwhat/utils.py
+++ b/sheetwhat/utils.py
@@ -83,3 +83,11 @@ def normalize_array_2d(array_2d):
 
 def map_2d(func, array_2d):
     return [[func(cell) for cell in row] for row in array_2d]
+
+
+def dict_keys(*dicts):
+    key_set = set()
+    for dict_i in dicts:
+        if isinstance(dict_i, dict):
+            key_set = key_set | set(dict_i)
+    return key_set

--- a/tests/test_has_equal_pivot.py
+++ b/tests/test_has_equal_pivot.py
@@ -348,7 +348,16 @@ def test_check_pivots_two_values(
             ),
             "A1",
             False,
-            "error",
+            None,
+        ),
+        (
+            Mutation(
+                ["pivotTables", 0, 0, "criteria", "2", "visibleValues", 0],
+                "something else",
+            ),
+            "A1",
+            False,
+            None,
         ),
     ],
 )

--- a/tests/test_has_equal_pivot.py
+++ b/tests/test_has_equal_pivot.py
@@ -327,7 +327,7 @@ def test_check_pivots_two_values(
             Deletion(["pivotTables", 0, 0, "criteria", "2", "visibleValues", 0]),
             "A1",
             False,
-            None,
+            r"1 issue(.|\s)*filtered out values(.|\s)*incorrect",
         ),
         (
             Addition(
@@ -336,7 +336,16 @@ def test_check_pivots_two_values(
             ),
             "A1",
             False,
-            None,
+            r"1 issue(.|\s)*filtered out values(.|\s)*incorrect",
+        ),
+        (
+            Mutation(
+                ["pivotTables", 0, 0, "criteria", "2", "visibleValues", 0],
+                "something else",
+            ),
+            "A1",
+            False,
+            r"1 issue(.|\s)*filtered out values(.|\s)*incorrect",
         ),
         (
             compose(
@@ -348,16 +357,7 @@ def test_check_pivots_two_values(
             ),
             "A1",
             False,
-            None,
-        ),
-        (
-            Mutation(
-                ["pivotTables", 0, 0, "criteria", "2", "visibleValues", 0],
-                "something else",
-            ),
-            "A1",
-            False,
-            None,
+            r"1 issue(.|\s)*rows or columns used(.|\s)*incorrect",
         ),
     ],
 )

--- a/tests/test_has_equal_pivot.py
+++ b/tests/test_has_equal_pivot.py
@@ -409,7 +409,6 @@ def test_check_pivot_criteria(
         has_equal_pivot(s)
 
 
-@pytest.mark.debug
 @pytest.mark.parametrize(
     "trans, sct_range, correct, message_contains",
     [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ from sheetwhat.utils import (
     is_empty,
     normalize_array_2d,
     map_2d,
+    dict_keys,
 )
 
 
@@ -113,3 +114,19 @@ def test_normalize_array_2d(array_2d, target):
 )
 def test_map_2d(array_2d, func, target):
     assert map_2d(func, array_2d) == target
+
+
+@pytest.mark.parametrize(
+    "dicts, result",
+    [
+        ([{"a": 1}], {"a"}),
+        (["test"], set()),
+        ([{"a": 2, "b": 5}], {"a", "b"}),
+        ("test", set()),
+        ([{"a": 2, "b": 5}, {"c": 2}], {"a", "b", "c"}),
+        ([{"a": 2, "b": 5}, {"a": 2}], {"a", "b"}),
+        ([{"a": 2, "b": 5}, {"a": 2, "c": 8}], {"a", "b", "c"}),
+    ],
+)
+def test_dict_keys(dicts, result):
+    assert dict_keys(*dicts) == result


### PR DESCRIPTION
Implement pivot table SCT logic for:

- Filtering, previously implemented here https://github.com/datacamp/feedback-api/commit/d41a9d845303bdc4dbc323a1f8d797008d8e9938 in the Javascript version of SCT checking.
- Calculated fields, previously implemented here https://github.com/datacamp/feedback-api/commit/5569ce5ac16ca52ab4dbbc04f8f79fc5c796ef4a in the Javascript version of SCT checking.

The messaging might have changed to better fit the sheetwhat conventions. Feel free to adapt.

Made sure the test coverage remained 100%.