### PR TITLE
Vvnkr/improve conditional formats

### DIFF
--- a/sheetwhat/Range.py
+++ b/sheetwhat/Range.py
@@ -1,0 +1,64 @@
+from .utils import range_to_row_columns
+
+
+class Range:
+    def __init__(self, range_input):
+        if isinstance(range_input, str):
+            self.__init_str(range_input)
+        elif isinstance(range_input, dict):
+            self.__init_dict(range_input)
+        else:
+            raise TypeError("range_input should be str or dict")
+
+    def __init_str(self, range_str):
+        range_dict = range_to_row_columns(range_str)
+        self.__init_from_range_dict(range_dict)
+
+    def __init_dict(self, range_dict):
+        if "startRowIndex" in range_dict and "startColumnIndex" in range_dict:
+            start_column = range_dict["startColumnIndex"]
+            assert start_column >= 0
+            end_column = range_dict.get("endColumnIndex", start_column + 1)
+            assert end_column > start_column
+            start_row = range_dict["startRowIndex"]
+            assert start_row >= 0
+            end_row = range_dict.get("endRowIndex", start_row + 1)
+            assert end_row > start_row
+            self.__init_from_range_dict(
+                {
+                    "start_column": start_column,
+                    "start_row": start_row,
+                    "end_column": end_column,
+                    "end_row": end_row,
+                }
+            )
+        else:
+            raise TypeError("did not recognize dictionary structure")
+
+    def __init_from_range_dict(self, range_dict):
+        self.start_column = range_dict["start_column"]
+        self.end_column = range_dict["end_column"]
+        self.start_row = range_dict["start_row"]
+        self.end_row = range_dict["end_row"]
+
+    def __eq__(self, other_range):
+        if isinstance(other_range, Range):
+            return (
+                self.start_column == other_range.start_column
+                and self.end_column == other_range.end_column
+                and self.start_row == other_range.start_row
+                and self.end_row == other_range.end_row
+            )
+        else:
+            return False
+
+    def is_within(self, other_range):
+        if isinstance(other_range, Range):
+            return (
+                self.start_column >= other_range.start_column
+                and self.end_column <= other_range.end_column
+                and self.start_row >= other_range.start_row
+                and self.end_row <= other_range.end_row
+            )
+        else:
+            return False

--- a/sheetwhat/checks/check_chart.py
+++ b/sheetwhat/checks/check_chart.py
@@ -1,4 +1,5 @@
 import functools
+
 from ..utils import range_to_row_columns, row_columns_to_range
 from .rules import with_rules, safe_glom
 

--- a/sheetwhat/checks/check_funcs.py
+++ b/sheetwhat/checks/check_funcs.py
@@ -11,7 +11,6 @@ import re
 
 
 def check_range(state, field, field_msg, missing_msg=None):
-
     student_field_content = crop_by_range(state.student_data[field], state.sct_range)
     solution_field_content = crop_by_range(state.solution_data[field], state.sct_range)
 

--- a/tests/test_Range.py
+++ b/tests/test_Range.py
@@ -1,0 +1,121 @@
+
+
+import pytest
+
+
+from sheetwhat.Range import Range
+
+
+@pytest.mark.parametrize("range_str", ["A1", "Z1", "A1:Z100", "AZFDDS124324"])
+def test_constructor_str(range_str):
+    Range(range_str)
+
+
+@pytest.mark.parametrize(
+    "range_dict",
+    [
+        {"startRowIndex": 0, "startColumnIndex": 0},
+        {"startRowIndex": 21, "startColumnIndex": 0},
+        {"startRowIndex": 21, "endRowIndex": 25, "startColumnIndex": 0},
+        {"startRowIndex": 21, "startColumnIndex": 0, "endColumnIndex": 5},
+        {
+            "startRowIndex": 21,
+            "endRowIndex": 25,
+            "startColumnIndex": 0,
+            "endColumnIndex": 5,
+        },
+    ],
+)
+def test_constructor_dict(range_dict):
+    Range(range_dict)
+
+
+@pytest.mark.parametrize(
+    "range_dict",
+    [
+        {
+            "startRowIndex": 21,
+            "endRowIndex": 20,
+            "startColumnIndex": 0,
+            "endColumnIndex": 5,
+        },
+        {
+            "startRowIndex": 21,
+            "endRowIndex": 25,
+            "startColumnIndex": 5,
+            "endColumnIndex": 4,
+        },
+        {"startRowIndex": -21, "startColumnIndex": 0},
+        {"startRowIndex": 21, "startColumnIndex": -5},
+    ],
+)
+def test_constructor_dict_fail(range_dict):
+    with pytest.raises(AssertionError):
+        Range(range_dict)
+
+
+@pytest.mark.parametrize("range_dict", [{}, [], lambda x: "bla"])
+def test_constructor_dict_fail_key(range_dict):
+    with pytest.raises(TypeError):
+        Range(range_dict)
+
+
+@pytest.mark.parametrize(
+    "range_1_input, range_2_input, equals",
+    [
+        ("A1", "A1", True),
+        ("A1", "B1", False),
+        ("A1:B100", "A1:B100", True),
+        ("A1:B100", "A1:B101", False),
+        ("A1", {"startRowIndex": 0, "startColumnIndex": 0}, True),
+        ({"startRowIndex": 0, "startColumnIndex": 0}, "A1", True),
+        ({"startRowIndex": 1, "startColumnIndex": 0}, "A1", False),
+        ({"startRowIndex": 0, "endRowIndex": 1, "startColumnIndex": 0}, "A1", True),
+        (
+            {
+                "startRowIndex": 0,
+                "endRowIndex": 1,
+                "startColumnIndex": 0,
+                "endColumnIndex": 1,
+            },
+            "A1",
+            True,
+        ),
+        (
+            {
+                "startRowIndex": 0,
+                "endRowIndex": 4,
+                "startColumnIndex": 0,
+                "endColumnIndex": 3,
+            },
+            "A1:C4",
+            True,
+        ),
+    ],
+)
+def test_equals(range_1_input, range_2_input, equals):
+    assert (Range(range_1_input) == Range(range_2_input)) == equals
+
+
+def test_equals_other_instance():
+    assert Range("A1") != "other_type"
+
+
+@pytest.mark.parametrize(
+    "range_1_input, range_2_input, equals",
+    [
+        ("A1", "A1", True),
+        ("A1", "B1", False),
+        ("A1", "A1:A5", True),
+        ("A1:A5", "A1:A4", False),
+        ("A1:A5", "A1:B100", True),
+        ("A1:A5", "B1:B5", False),
+        ("A1:A5", "A1:A5", True),
+    ],
+)
+def test_is_within(range_1_input, range_2_input, equals):
+    assert (Range(range_1_input).is_within(Range(range_2_input))) == equals
+
+
+def test_is_wihtin_other_instance():
+    assert not (Range("B1").is_within("other_type"))

--- a/tests/test_has_equal_conditional_formats.py
+++ b/tests/test_has_equal_conditional_formats.py
@@ -195,3 +195,11 @@ def test_has_equal_conditional_formats_fail(solution_data):
     Ex = setup_ex_state(user_data, solution_data, "A1")
     with verify_success(True):
         Ex.has_equal_conditional_formats()
+
+
+def test_has_equal_conditional_formats_out_of_range(solution_data):
+    user_data = deepcopy(solution_data)
+    user_data["conditionalFormats"][0]["booleanRule"] = {}
+    Ex = setup_ex_state(user_data, solution_data, "Z1")
+    with verify_success(True):
+        Ex.has_equal_conditional_formats()

--- a/tests/test_has_equal_conditional_formats.py
+++ b/tests/test_has_equal_conditional_formats.py
@@ -1,6 +1,8 @@
 import pytest
 from copy import deepcopy
 from tests.helper import (
+    compose,
+    Addition,
     Deletion,
     Identity,
     Mutation,
@@ -51,10 +53,11 @@ def conditional_format_2(conditional_format):
             "ranges": [
                 {
                     "sheetId": "Sheet1",
-                    "endRowIndex": 12,
-                    "startRowIndex": 2,
-                    "endColumnIndex": 8,
-                    "startColumnIndex": 5,
+                    # A1:C4
+                    "endRowIndex": 4,
+                    "startRowIndex": 0,
+                    "endColumnIndex": 3,
+                    "startColumnIndex": 0,
                 }
             ],
             "gradientRule": {
@@ -119,7 +122,10 @@ def solution_data_2(conditional_format_2):
             "format of the first rule is incorrect",
         ),
         (
-            Mutation(["conditionalFormats", 0], {"gradientRule": {}}),
+            compose(
+                Deletion(["conditionalFormats", 0, "booleanRule"]),
+                Mutation(["conditionalFormats", 0, "gradientRule"], {}),
+            ),
             False,
             "single color",
         ),
@@ -138,7 +144,10 @@ def test_has_equal_conditional_formats(solution_data, trans, correct, match):
     [
         (Identity(), True, None),
         (
-            Mutation(["conditionalFormats", 1], {"booleanRule": {}}),
+            compose(
+                Deletion(["conditionalFormats", 1, "gradientRule"]),
+                Mutation(["conditionalFormats", 1, "booleanRule"], {}),
+            ),
             False,
             "second .* color scale",
         ),
@@ -171,7 +180,6 @@ def test_has_equal_conditional_formats_3(solution_data_2, trans, correct, match)
         has_equal_conditional_formats(s)
 
 
-@pytest.mark.debug
 def test_has_equal_conditional_formats_fail(solution_data):
     user_data = deepcopy(solution_data)
     user_data["conditionalFormats"][0]["ranges"] = [

--- a/tests/test_has_equal_conditional_formats.py
+++ b/tests/test_has_equal_conditional_formats.py
@@ -1,6 +1,13 @@
 import pytest
 from copy import deepcopy
-from tests.helper import Deletion, Identity, Mutation, setup_state, verify_success
+from tests.helper import (
+    Deletion,
+    Identity,
+    Mutation,
+    setup_state,
+    setup_ex_state,
+    verify_success,
+)
 
 from sheetwhat.checks import has_equal_conditional_formats
 
@@ -12,10 +19,11 @@ def conditional_format():
             "ranges": [
                 {
                     "sheetId": "Sheet1",
-                    "endRowIndex": 12,
-                    "startRowIndex": 2,
-                    "endColumnIndex": 8,
-                    "startColumnIndex": 5,
+                    # A1:C4
+                    "endRowIndex": 4,
+                    "startRowIndex": 0,
+                    "endColumnIndex": 3,
+                    "startColumnIndex": 0,
                 }
             ],
             "booleanRule": {
@@ -161,3 +169,21 @@ def test_has_equal_conditional_formats_3(solution_data_2, trans, correct, match)
     s = setup_state(user_data, solution_data_2, "A1")
     with verify_success(correct, match=match):
         has_equal_conditional_formats(s)
+
+
+@pytest.mark.debug
+def test_has_equal_conditional_formats_fail(solution_data):
+    user_data = deepcopy(solution_data)
+    user_data["conditionalFormats"][0]["ranges"] = [
+        {
+            "sheetId": "Sheet1",
+            # A1:C5
+            "endRowIndex": 5,
+            "startRowIndex": 0,
+            "endColumnIndex": 3,
+            "startColumnIndex": 0,
+        }
+    ]
+    Ex = setup_ex_state(user_data, solution_data, "A1")
+    with verify_success(True):
+        Ex.has_equal_conditional_formats()


### PR DESCRIPTION
Conditional formats previously checked all the conditional formats of a sheet, ignoring the range where the SCT was defined. These changes actually check conditional format rules on a specific range.

This avoids weird behaviour where ranges are defined differently in the conditional format rule, but the effect on the sheet remains the same.

Happy to provide more details in a quick call.

(from pair programming session with @ddmkr)

@hermansje 