### PR TITLE
feat: add two new chart checks and fix spelling

### DIFF
--- a/sheetwhat/checks/__init__.py
+++ b/sheetwhat/checks/__init__.py
@@ -13,6 +13,8 @@ from sheetwhat.checks.check_chart import (
     has_equal_domain,
     has_equal_title,
     has_equal_series,
+    has_equal_single_series,
+    has_equal_node,
 )
 from sheetwhat.checks.has_equal_conditional_formats import has_equal_conditional_formats
 

--- a/sheetwhat/checks/rules.py
+++ b/sheetwhat/checks/rules.py
@@ -94,7 +94,7 @@ class EqualityRule(Rule):
     def call(self, path, message, equal_func=lambda x, y: x == y):
         solution_field = safe_glom(self.solution_structure, path)
         student_field = safe_glom(self.student_structure, path)
-        if not equal_func(solution_field, student_field):
+        if not equal_func(student_field, solution_field):
             self.issues.append(
                 message.format(expected=solution_field, actual=student_field)
             )


### PR DESCRIPTION
- Added `has_equal_single_series`, which you can use to check one
specific series of a chart.
- Added `has_equal_node`, which is a generic checker, not to be
documented but it can be used as temporary measure.
- Fixed spelling to avoid using singular 'serie', since it doesn't
exist.