### PR TITLE
feat: add simple number format check and test

### DIFF
--- a/sheetwhat/checks/__init__.py
+++ b/sheetwhat/checks/__init__.py
@@ -8,6 +8,7 @@ from sheetwhat.checks.check_funcs import (
     check_operator,
 )
 from sheetwhat.checks.has_equal_pivot import has_equal_pivot
+from sheetwhat.checks.has_equal_number_format import has_equal_number_format
 from sheetwhat.checks.check_chart import (
     check_chart,
     has_equal_domain,

--- a/sheetwhat/checks/has_equal_number_format.py
+++ b/sheetwhat/checks/has_equal_number_format.py
@@ -1,0 +1,47 @@
+from .check_funcs import check_range
+from .rules import safe_glom
+
+number_format_types = {
+    "TEXT": "text",
+    "NUMBER": "a number",
+    "PERCENT": "a percent",
+    "CURRENCY": "a currency",
+    "DATE": "a date",
+    "TIME": "a time",
+    "DATE_TIME": "a date time",
+    "SCIENTIFIC": "a scientific number",
+}
+
+
+def has_equal_number_format(state, incorrect_msg=None):
+    child = check_range(state, field="numberFormats", field_msg="number format")
+
+    student_number_format = child.student_data["numberFormats"]
+    solution_number_format = child.solution_data["numberFormats"]
+
+    generated_message = None
+    standard_message = "In cell `{range}`, did you use the correct number format?"
+
+    type_path = "0.0.numberFormat.type"
+    student_number_format_type = safe_glom(student_number_format, type_path)
+    solution_number_format_type = safe_glom(solution_number_format, type_path)
+    if student_number_format_type != solution_number_format_type:
+        actual_type = number_format_types.get(student_number_format_type)
+        expected_type = number_format_types.get(solution_number_format_type)
+        if actual_type is None or expected_type is None:
+            generated_message = standard_message
+        else:
+            generated_message = (
+                standard_message + f" Expected {expected_type}, but got {actual_type}."
+            )
+    elif student_number_format != solution_number_format:
+        generated_message = standard_message
+
+    if generated_message is not None:
+        child.do_test(
+            (incorrect_msg or generated_message).format(
+                **state.to_message_exposed_dict()
+            )
+        )
+
+    return state

--- a/sheetwhat/checks/has_equal_number_format.py
+++ b/sheetwhat/checks/has_equal_number_format.py
@@ -22,6 +22,8 @@ def has_equal_number_format(state, incorrect_msg=None):
     generated_message = None
     standard_message = "In cell `{range}`, did you use the correct number format?"
 
+    # For now, we generally only support cells, not ranges. This means we always
+    # have to look at the content at index 0, 0.
     type_path = "0.0.numberFormat.type"
     student_number_format_type = safe_glom(student_number_format, type_path)
     solution_number_format_type = safe_glom(solution_number_format, type_path)

--- a/tests/test_has_equal_number_format.py
+++ b/tests/test_has_equal_number_format.py
@@ -1,0 +1,115 @@
+import pytest
+from copy import deepcopy
+from tests.helper import Identity, Mutation, setup_state, verify_success
+from sheetwhat.checks import has_equal_number_format
+
+# Fixtures
+@pytest.fixture()
+def user_data_seed():
+    return {
+        "numberFormats": [
+            [
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+            ],
+            [
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+            ],
+            [
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+            ],
+            [
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+            ],
+            [
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+            ],
+            [
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+            ],
+        ]
+    }
+
+
+# Tests
+@pytest.mark.parametrize(
+    "trans, sct_range, correct, match",
+    [
+        (Identity(), "A1", True, None),
+        (Identity(), "A1:B2", True, None),
+        (
+            Mutation(
+                ["numberFormats", 0, 0],
+                {"numberFormat": {"type": "NUMBER", "pattern": "0.00"}},
+            ),
+            "A1",
+            True,
+            None,
+        ),
+        (
+            Mutation(["numberFormats", 1, 0, "numberFormat", "type"], "TEXT"),
+            "A2",
+            False,
+            "Expected a number, but got text",
+        ),
+        (
+            Mutation(["numberFormats", 0, 1, "numberFormat", "type"], "UNKONWN"),
+            "B1",
+            False,
+            "In cell `B1`, did you use the correct number format?",
+        ),
+        (
+            Mutation(["numberFormats", 1, 1, "numberFormat", "patter"], "0.0"),
+            "B2",
+            False,
+            "In cell `B2`, did you use the correct number format?",
+        ),
+
+    ],
+)
+def test_has_equal_number_format(user_data_seed, trans, sct_range, correct, match):
+    user_data = trans(deepcopy(user_data_seed))
+    s = setup_state(user_data, user_data_seed, sct_range)
+    with verify_success(correct, match=match):
+        has_equal_number_format(s)


### PR DESCRIPTION
Add number formatting test, which is very similar to how formulas or
values are checked. If the type of the number format is different, a
more specific message can be generated.