### PR TITLE
chore: cleanup readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-> :warning: **This repo has outdated tokens in its travisci config**
-> To make new releases for this project it needs to be moved to circleci
-
 # sheetwhat
 
 [![PyPI version](https://badge.fury.io/py/sheetwhat.svg)](https://badge.fury.io/py/sheetwhat)


### PR DESCRIPTION
This PR removes the travisci disclaimer since the project was moved over to circleci.